### PR TITLE
replace use of Task.leftShift with Task.doLast

### DIFF
--- a/plugin/src/main/groovy/com/github/fowlie/GradleJenkinsTestPlugin.groovy
+++ b/plugin/src/main/groovy/com/github/fowlie/GradleJenkinsTestPlugin.groovy
@@ -7,8 +7,10 @@ class GradleJenkinsTestPlugin implements Plugin<Project> {
     @Override
     void apply(Project project) {
         project.apply(plugin: 'java')
-        project.task('jenkinsTest', type: GradleJenkinsTestTask) << {
-            description 'Updates the test report timestamps, so Jenkins doesn\'t mark the job as failed.'
+        project.task('jenkinsTest', type: GradleJenkinsTestTask) {
+            doLast {
+                description 'Updates the test report timestamps, so Jenkins doesn\'t mark the job as failed.'
+            }
         }
         project.test.dependsOn project.jenkinsTest
     }


### PR DESCRIPTION
The use of Task.leftShift is deprecated and will be removed in Gradle 5.0